### PR TITLE
Switch to adoptopenjdk JRE image

### DIFF
--- a/components/ord-service/Dockerfile
+++ b/components/ord-service/Dockerfile
@@ -28,7 +28,7 @@ RUN ./run.sh --skip-deps --no-start --skip-tests && \
     VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout -q) && \
     mkdir /app && mv ./target/ord-service-$VERSION.jar /app/ord-service.jar
 
-FROM openjdk:8-jre-slim
+FROM adoptopenjdk/openjdk8:alpine-jre
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 
@@ -42,7 +42,7 @@ COPY --from=builder /app/ord-service.jar /app/
 # Install curl & CA certs
 #
 
-RUN apt-get update && apt-get install -y curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add curl ca-certificates
 
 #
 # Run app


### PR DESCRIPTION
**Description**
OpenJDK official images for [JRE 8](https://hub.docker.com/_/openjdk?tab=tags&page=1&ordering=last_updated&name=8-jre-alpine) are more than 2 years old. 
AdoptOpenJDK images are more frequently updated and their [alpine-jre](https://hub.docker.com/r/adoptopenjdk/openjdk8/tags?page=1&ordering=last_updated&name=alpine-jre) image is 2 days old. 

Changes proposed in this pull request:
- Adopt fresh image from AdoptOpenJDK project based on Alpine and with JRE 8