### PR TITLE
Adapting ORD RC2 

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -131,4 +131,13 @@ public class APIEntity {
             joinColumns = @JoinColumn(name = "product_id"),
             inverseJoinColumns = @JoinColumn(name = "api_definiton_id"))
     private Set<ProductEntity> products;
+
+    @Column(name = "implementation_standard")
+    private String implementationStandard;
+
+    @Column(name = "custom_implementation_standard")
+    private String customImplementationStandard;
+
+    @Column(name = "custom_implementation_standard_description")
+    private String customImplementationStandardDescription;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -109,9 +109,9 @@ public class APIEntity {
     @CollectionTable(name = "changelog_entries", joinColumns = @JoinColumn(name = "api_definition_id"))
     private List<ChangelogEntry> changelogEntries;
 
-    @Column(name = "target_url", length = 256)
-    @NotNull
-    private String entryPoint;
+    @ElementCollection
+    @CollectionTable(name = "target_urls", joinColumns = @JoinColumn(name = "api_definition_id"))
+    private List<ArrayElement> entryPoints;
 
     @ElementCollection
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "api_definition_id"))

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -51,11 +51,9 @@ public class APIEntity {
     @NotNull
     private UUID partOfPackage;
 
-    @Column(name = "bundle_id")
-    @Convert("uuidConverter")
-    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
-    @NotNull
-    private UUID partOfConsumptionBundle;
+    @ElementCollection
+    @CollectionTable(name = "api_bundle_reference", joinColumns = @JoinColumn(name = "api_definition_id"))
+    private List<ConsumptionBundleReference> partOfConsumptionBundles;
 
     @Column(name = "api_protocol")
     private String apiProtocol;
@@ -121,9 +119,12 @@ public class APIEntity {
     @JoinColumn(name = "package_id", insertable = false, updatable = false)
     private PackageEntity pkg;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bundle_id", insertable = false, updatable = false)
-    private BundleEntity consumptionBundle;
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "bundle_references",
+            joinColumns = @JoinColumn(name = "api_def_id"),
+            inverseJoinColumns = @JoinColumn(name = "bundle_id"))
+    private Set<BundleEntity> consumptionBundles;
 
     @ManyToMany
     @JoinTable(

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
@@ -63,9 +63,9 @@ public class BundleEntity {
     @JoinColumn(name = "app_id", insertable = false, updatable = false)
     private SystemInstanceEntity systemInstance;
 
-    @OneToMany(mappedBy = "consumptionBundle", fetch = FetchType.LAZY)
+    @ManyToMany(mappedBy = "consumptionBundles", fetch = FetchType.LAZY)
     private Set<APIEntity> apis;
 
-    @OneToMany(mappedBy = "consumptionBundle", fetch = FetchType.LAZY)
+    @ManyToMany(mappedBy = "consumptionBundles", fetch = FetchType.LAZY)
     private Set<EventEntity> events;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ConsumptionBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ConsumptionBundleReference.java
@@ -6,7 +6,7 @@ import javax.persistence.Embeddable;
 @Embeddable
 public class ConsumptionBundleReference {
     @Column(name = "bundle_id", length = 256)
-    private String ordId;
+    private String bundleID;
 
     @Column(name = "default_entry_point", length = 256)
     private String defaultEntryPoint;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ConsumptionBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ConsumptionBundleReference.java
@@ -1,0 +1,13 @@
+package com.sap.cloud.cmp.ord.service.storage.model;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class ConsumptionBundleReference {
+    @Column(name = "bundle_id", length = 256)
+    private String ordId;
+
+    @Column(name = "default_entry_point", length = 256)
+    private String defaultEntryPoint;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -62,11 +62,9 @@ public class EventEntity {
     @NotNull
     private UUID partOfPackage;
 
-    @Column(name = "bundle_id")
-    @Convert("uuidConverter")
-    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
-    @NotNull
-    private UUID partOfConsumptionBundle;
+    @ElementCollection
+    @CollectionTable(name = "event_bundle_reference", joinColumns = @JoinColumn(name = "event_definition_id"))
+    private List<ConsumptionBundleReference> partOfConsumptionBundles;
 
     @ElementCollection
     @CollectionTable(name = "links", joinColumns = @JoinColumn(name = "event_definition_id"))
@@ -110,9 +108,12 @@ public class EventEntity {
     @JoinColumn(name = "package_id", insertable = false, updatable = false)
     private PackageEntity pkg;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bundle_id", insertable = false, updatable = false)
-    private BundleEntity consumptionBundle;
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "bundle_references",
+            joinColumns = @JoinColumn(name = "event_def_id"),
+            inverseJoinColumns = @JoinColumn(name = "bundle_id"))
+    private Set<BundleEntity> consumptionBundles;
 
     @ManyToMany
     @JoinTable(

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
@@ -49,8 +49,9 @@ public class ProductEntity {
     @Column(name = "parent", length = 256)
     private String parent;
 
-    @Column(name = "sap_ppms_object_id", length = 256)
-    private String sapPpmsObjectId;
+    @ElementCollection
+    @CollectionTable(name = "correlation_ids", joinColumns = @JoinColumn(name = "product_id"))
+    private List<ArrayElement> correlationIds;
 
     @ElementCollection
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "product_id"))

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
@@ -53,4 +53,8 @@ public class SystemInstanceEntity {
     @ElementCollection
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "application_id"))
     private List<Label> labels;
+
+    @ElementCollection
+    @CollectionTable(name = "correlation_ids", joinColumns = @JoinColumn(name = "application_id"))
+    private List<ArrayElement> correlationIds;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
@@ -23,9 +23,8 @@ public class VendorEntity {
     @NotNull
     private String title;
 
-    @Column(name = "type", length = 256)
-    @NotNull
-    private String type;
+    @Column(name = "sap_partner")
+    private boolean sapPartner;
 
     @ElementCollection
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "vendor_id"))


### PR DESCRIPTION
**Description**

Currently, the relation between Bundles and Apis/Events is One-to-Many (a single Bundle can have many Apis/Events but a single Api/Event can be part of only one Bundle).

This PR introduces Many-to-Many relation between Bundles and Apis/Events (a single Bundle can have many Apis/Events and a single Api/Event can be part of many Bundles) due to ORD requirements. 

In addition, there are changes and adaptations to fields corresponding to ORD RC2.

**Related issue(s)**
- 


