### PR TITLE
Use baseURL from request context for spec URL instead of env

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
@@ -20,7 +20,7 @@ public class UrlConverter implements AttributeConverter<String, String> {
 
     @Override
     public String convertToEntityAttribute(String s) {
-        return env.getProperty("static.request_mapping_path") + s;
+        return "/" + env.getProperty("static.request_mapping_path") + s;
     }
 
     @Autowired

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
@@ -3,9 +3,13 @@ package com.sap.cloud.cmp.ord.service.storage.model.converter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+import javax.servlet.http.HttpServletRequest;
 
 @Converter
 @Component
@@ -13,14 +17,16 @@ public class UrlConverter implements AttributeConverter<String, String> {
 
     private static Environment env;
 
-    @Override
     public String convertToDatabaseColumn(String s) {
         return null; // ORD Service is read only
     }
 
-    @Override
     public String convertToEntityAttribute(String s) {
-        return "/" + env.getProperty("static.request_mapping_path") + s;
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        HttpServletRequest req = ((ServletRequestAttributes) requestAttributes).getRequest();
+        String baseURL = req.getRequestURL().toString().replace(req.getRequestURI(), "");
+
+        return baseURL + "/" + env.getProperty("static.request_mapping_path") + s;
     }
 
     @Autowired

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
@@ -20,7 +20,7 @@ public class UrlConverter implements AttributeConverter<String, String> {
 
     @Override
     public String convertToEntityAttribute(String s) {
-        return env.getProperty("server.self_url") + "/" + env.getProperty("static.request_mapping_path") + s;
+        return env.getProperty("static.request_mapping_path") + s;
     }
 
     @Autowired

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverter.java
@@ -31,7 +31,7 @@ public class UrlConverter implements AttributeConverter<String, String> {
         String baseURL = req.getRequestURL().toString().replace(req.getRequestURI(), "");
 
         String externalHost = req.getHeader(EXTERNAL_HOST_HEADER);
-        if (externalHost != null && !externalHost.isEmpty()) { // ORD Service is behind of a reverse proxy (istio ingressgateway when running in cluster)
+        if (externalHost != null && !externalHost.isEmpty()) { // ORD Service is behind a reverse proxy (istio ingressgateway when running in cluster)
             String protocol = req.getHeader(PROTOCOL_HEADER);
             if (protocol == null || protocol.isEmpty()) {
                 protocol = "https";

--- a/components/ord-service/src/main/resources/application.yml
+++ b/components/ord-service/src/main/resources/application.yml
@@ -16,7 +16,6 @@ static:
     path_prefix: "v0"
   request_mapping_path: "open-resource-discovery-static/${static.api.path_prefix}"
 server:
-  self_url: http://localhost:8080
   port: 8080
   default_response_type: "xml"
 spring:

--- a/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
+++ b/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
@@ -23,7 +23,7 @@ public class UrlConverterTest {
         String path = "/v1/api";
 
         String actualUrl = urlConverter.convertToEntityAttribute(path);
-        String expectedUrl = requestMappingPath + path;
+        String expectedUrl = "/" + requestMappingPath + path;
 
         assertEquals(expectedUrl, actualUrl);
     }

--- a/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
+++ b/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
@@ -23,7 +23,7 @@ public class UrlConverterTest {
         String path = "/v1/api";
 
         String actualUrl = urlConverter.convertToEntityAttribute(path);
-        String expectedUrl = "/" + requestMappingPath + path;
+        String expectedUrl = "http://localhost/" + requestMappingPath + path;
 
         assertEquals(expectedUrl, actualUrl);
     }

--- a/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
+++ b/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/storage/model/converter/UrlConverterTest.java
@@ -12,9 +12,6 @@ import static org.junit.Assert.assertEquals;
 @SpringBootTest(classes = UrlConverter.class)
 public class UrlConverterTest {
 
-    @Value("${server.self_url}")
-    private String serverUrl;
-
     @Value("${static.request_mapping_path}")
     private String requestMappingPath;
 
@@ -26,7 +23,7 @@ public class UrlConverterTest {
         String path = "/v1/api";
 
         String actualUrl = urlConverter.convertToEntityAttribute(path);
-        String expectedUrl = serverUrl + "/" + requestMappingPath + path;
+        String expectedUrl = requestMappingPath + path;
 
         assertEquals(expectedUrl, actualUrl);
     }

--- a/components/ord-service/src/test/resources/application.yml
+++ b/components/ord-service/src/test/resources/application.yml
@@ -16,7 +16,6 @@ static:
     path_prefix: "v0"
   request_mapping_path: "open-resource-discovery-static/${static.api.path_prefix}"
 server:
-  self_url: http://localhost:8080
   port: 8080
   default_response_type: "xml"
 spring:


### PR DESCRIPTION
**Description**

With https://github.com/kyma-incubator/compass/pull/1981 ORD Service will be hosted on two different gateways (base urls), therefore we need to get the baseURL dynamically from the request.


