### PR TITLE
Expose additional System Instance metadata

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
@@ -28,6 +28,12 @@ public class SystemInstanceEntity {
     @Column(name = "description", length = Integer.MAX_VALUE)
     private String description;
 
+    @Column(name = "system_number", length = 256)
+    private String systemNumber;
+
+    @Column(name = "product_type", length = 256)
+    private String productType;
+
     @OneToMany(mappedBy = "systemInstance", fetch = FetchType.LAZY)
     private Set<PackageEntity> packages;
 


### PR DESCRIPTION
We can expose additional metadata in the System Instance entity on top of ORD.

Newly exposed fields:
- Product Type
- System Number