### PR TITLE
Allow extensive ord querying

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/health/ReadinessHealthIndicator.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/health/ReadinessHealthIndicator.java
@@ -2,6 +2,8 @@ package com.sap.cloud.cmp.ord.service.health;
 
 import com.sap.cloud.cmp.ord.service.repository.SchemaRepository;
 import com.sap.cloud.cmp.ord.service.storage.model.SchemaEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
@@ -10,9 +12,12 @@ import org.springframework.stereotype.Component;
 
 @Component("schemaCompatibility")
 public class ReadinessHealthIndicator implements HealthIndicator {
+    private static final Logger logger = LoggerFactory.getLogger(ReadinessHealthIndicator.class);
+    private final String DEFAULT_SCHEMA_MIGRATION_VERSION = "0";
+
     private boolean isHealthy = false;
 
-    @Value("${schema.migration_version}")
+    @Value("${schema.migration_version:0}")
     private String version;
 
     @Autowired
@@ -20,6 +25,9 @@ public class ReadinessHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
+        if (version.equals(DEFAULT_SCHEMA_MIGRATION_VERSION)) {
+            logger.warn("Missing schema migration version. Set to default.");
+        }
 
         if (!isHealthy) {
             SchemaEntity schema = schemaRepository.getByVersionNotNull();

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -131,11 +131,11 @@ public class APIEntity {
             inverseJoinColumns = @JoinColumn(name = "bundle_id"))
     private Set<BundleEntity> consumptionBundles;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "api_product",
-            joinColumns = {@JoinColumn(name = "api_definition_id", referencedColumnName= "id"),@JoinColumn(name = "app_id", referencedColumnName= "app_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id", referencedColumnName= "ord_id"), @JoinColumn(name = "app_id", referencedColumnName= "app_id")})
+            joinColumns = {@JoinColumn(name = "api_definition_id")},
+            inverseJoinColumns = {@JoinColumn(name = "product_id")})
     private Set<ProductEntity> products;
 
     @Column(name = "implementation_standard")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIProduct.java
@@ -1,0 +1,24 @@
+package com.sap.cloud.cmp.ord.service.storage.model;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+
+@EdmIgnore
+@Table(name = "api_product")
+@Entity(name = "apiProduct")
+@IdClass(APIProduct.class)
+public class APIProduct implements Serializable {
+
+    @javax.persistence.Id
+    @Column(name = "api_definition_id", length = 256)
+    private String apiDefID;
+
+    @javax.persistence.Id
+    @Column(name = "product_id", length = 256)
+    private String productID;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIProduct.java
@@ -13,7 +13,6 @@ import java.io.Serializable;
 @Entity(name = "apiProduct")
 @IdClass(APIProduct.class)
 public class APIProduct implements Serializable {
-
     @javax.persistence.Id
     @Column(name = "api_definition_id", length = 256)
     private String apiDefID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleReference.java
@@ -1,21 +1,30 @@
 package com.sap.cloud.cmp.ord.service.storage.model;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import org.eclipse.persistence.annotations.Convert;
+import org.eclipse.persistence.annotations.TypeConverter;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import java.util.UUID;
 
 @EdmIgnore
 @Table(name = "bundle_references")
 @Entity(name = "bundleReference")
 public class BundleReference {
+    @javax.persistence.Id
+    @Column(name = "id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID Id;
+
     @Column(name = "api_def_id", length = 256)
     private String apiDefID;
 
     @Column(name = "event_def_id", length = 256)
     private String eventDefID;
 
-    @javax.persistence.Id
     @Column(name = "bundle_id", length = 256)
     private String bundleID;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleReference.java
@@ -1,0 +1,24 @@
+package com.sap.cloud.cmp.ord.service.storage.model;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@EdmIgnore
+@Table(name = "bundle_references")
+@Entity(name = "bundleReference")
+public class BundleReference {
+    @Column(name = "api_def_id", length = 256)
+    private String apiDefID;
+
+    @Column(name = "event_def_id", length = 256)
+    private String eventDefID;
+
+    @javax.persistence.Id
+    @Column(name = "bundle_id", length = 256)
+    private String bundleID;
+
+    @Column(name = "api_def_url", length = 256)
+    private String defaultEntryPoint;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -120,10 +120,10 @@ public class EventEntity {
             inverseJoinColumns = @JoinColumn(name = "bundle_id"))
     private Set<BundleEntity> consumptionBundles;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "event_product",
-            joinColumns = {@JoinColumn(name = "event_definition_id", referencedColumnName= "id"),@JoinColumn(name = "app_id", referencedColumnName= "app_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id", referencedColumnName= "ord_id"), @JoinColumn(name = "app_id", referencedColumnName= "app_id")})
+            joinColumns = {@JoinColumn(name = "event_definition_id")},
+            inverseJoinColumns = {@JoinColumn(name = "product_id")})
     private Set<ProductEntity> products;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventProduct.java
@@ -1,0 +1,23 @@
+package com.sap.cloud.cmp.ord.service.storage.model;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+
+@EdmIgnore
+@Table(name = "event_product")
+@Entity(name = "eventProduct")
+@IdClass(EventProduct.class)
+public class EventProduct implements Serializable {
+    @javax.persistence.Id
+    @Column(name = "event_definition_id", length = 256)
+    private String eventDefID;
+
+    @javax.persistence.Id
+    @Column(name = "product_id", length = 256)
+    private String productID;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
@@ -104,11 +104,11 @@ public class PackageEntity {
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "package_id"))
     private List<Label> labels;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "package_product",
-            joinColumns = {@JoinColumn(name = "package_id", referencedColumnName= "id"),@JoinColumn(name = "app_id", referencedColumnName= "app_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id", referencedColumnName= "ord_id"), @JoinColumn(name = "app_id", referencedColumnName= "app_id")})
+            joinColumns = {@JoinColumn(name = "package_id")},
+            inverseJoinColumns = {@JoinColumn(name = "product_id")})
     private Set<ProductEntity> products;
 
     @OneToMany(mappedBy = "pkg", fetch = FetchType.LAZY)

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageProduct.java
@@ -13,7 +13,6 @@ import java.io.Serializable;
 @Entity(name = "packageProduct")
 @IdClass(PackageProduct.class)
 public class PackageProduct implements Serializable {
-
     @javax.persistence.Id
     @Column(name = "package_id", length = 256)
     private String packageID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageProduct.java
@@ -1,0 +1,24 @@
+package com.sap.cloud.cmp.ord.service.storage.model;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+
+@EdmIgnore
+@Table(name = "package_product")
+@Entity(name = "packageProduct")
+@IdClass(PackageProduct.class)
+public class PackageProduct implements Serializable {
+
+    @javax.persistence.Id
+    @Column(name = "package_id", length = 256)
+    private String packageID;
+
+    @javax.persistence.Id
+    @Column(name = "product_id", length = 256)
+    private String productID;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
@@ -14,12 +14,12 @@ import java.util.UUID;
 @Entity(name = "product")
 @Table(name = "products")
 public class ProductEntity {
+    @javax.persistence.Id
     @Column(name = "id")
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID Id;
 
-    @javax.persistence.Id
     @Column(name = "ord_id", length = 256)
     @NotNull
     private String ordId;
@@ -65,13 +65,13 @@ public class ProductEntity {
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "product_id", referencedColumnName= "id"))
     private List<Label> labels;
 
-    @ManyToMany(mappedBy = "products")
+    @ManyToMany(mappedBy = "products", fetch = FetchType.LAZY)
     private Set<PackageEntity> packages;
 
-    @ManyToMany(mappedBy = "products")
+    @ManyToMany(mappedBy = "products", fetch = FetchType.LAZY)
     private Set<APIEntity> apis;
 
-    @ManyToMany(mappedBy = "products")
+    @ManyToMany(mappedBy = "products", fetch = FetchType.LAZY)
     private Set<EventEntity> events;
 
     @EdmProtectedBy(name = "tenant_id")


### PR DESCRIPTION
**Description**

This PR enables the ORD Service to support some odata filtering queries (`any`, `all` operators).

Changes proposed in this pull request:
- some new entities are added expressing the ManyToMany relation between the current ones.
- PK of `ProductEntity` is changed from `ordId` to `id` field
- based on the changed views, the join columns in the `@ManyToMany` relation between the entities are reduced/optimized
- a default value is set to the schema migration version regarding the readiness probe (without it running the ORD Service in debug mode fails)
