### PR TITLE
Allow providers to read consumers' specs

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -13,8 +13,8 @@ public abstract class Controller {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final String TENANTS_MAP_KEY = "tenant";
-    private final String CONSUMER_TENANT_KEY = "externalTenant";
-    private final String PROVIDER_TENANT_KEY = "providerExternalTenant";
+    private final String CONSUMER_TENANT_KEY = "consumerTenant";
+    private final String PROVIDER_TENANT_KEY = "providerTenant";
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String JWT_TOKEN_SPLIT_PARTS = "\\.";
     private final int PAYLOAD_INDEX = 1;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -34,7 +34,7 @@ public abstract class Controller {
             String idTokenDecoded = new String(idTokenBytes);
 
             JsonNode tokenTree = mapper.readTree(idTokenDecoded);
-            JsonNode tenantsTree = tokenTree.get(TENANTS_MAP_KEY);
+            JsonNode tenantsTree = mapper.readTree(tokenTree.get(TENANTS_MAP_KEY).asText().replace("\\",""));
 
             String tenantID = tenantsTree.path(CONSUMER_TENANT_KEY).asText();
             String providerTenantID = tenantsTree.path(PROVIDER_TENANT_KEY).asText();

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -35,15 +35,18 @@ public abstract class Controller {
 
             JsonNode tokenTree = mapper.readTree(idTokenDecoded);
             String unescapedTenants = tokenTree.get(TENANTS_MAP_KEY).asText().replace("\\", "");
+            try {
+                JsonNode tenantsTree = mapper.readTree(unescapedTenants);
 
-            JsonNode tenantsTree = mapper.readTree(unescapedTenants);
-
-            String tenantID = tenantsTree.path(CONSUMER_TENANT_KEY).asText();
-            String providerTenantID = tenantsTree.path(PROVIDER_TENANT_KEY).asText();
-            if (providerTenantID.isEmpty()) {
-                providerTenantID = tenantID;
+                String tenantID = tenantsTree.path(CONSUMER_TENANT_KEY).asText();
+                String providerTenantID = tenantsTree.path(PROVIDER_TENANT_KEY).asText();
+                if (providerTenantID.isEmpty()) {
+                    providerTenantID = tenantID;
+                }
+                tenantsPair = Pair.of(tenantID, providerTenantID);
+            }catch (IOException e){
+                tenantsPair = Pair.of("", "");
             }
-            tenantsPair = Pair.of(tenantID, providerTenantID);
         }
 
         return tenantsPair;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -2,6 +2,7 @@ package com.sap.cloud.cmp.ord.service.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.util.Pair;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -11,14 +12,16 @@ public abstract class Controller {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final String TENANT_KEY = "tenant";
+    private final String TENANTS_MAP_KEY = "tenants";
+    private final String CONSUMER_TENANT_KEY = "tenant";
+    private final String PROVIDER_TENANT_KEY = "provider_tenant";
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String JWT_TOKEN_SPLIT_PARTS = "\\.";
     private final int PAYLOAD_INDEX = 1;
 
-    String extractInternalTenantIdFromIDToken(final HttpServletRequest request) throws IOException {
+    Pair<String, String> extractTenantsFromIDToken(final HttpServletRequest request) throws IOException {
         final String idToken = request.getHeader(AUTHORIZATION_HEADER);
-        String tenantID = null;
+        Pair<String, String> tenantsPair = null;
 
         if (idToken != null && !idToken.isEmpty()) {
             // The id_token comes with `Bearer` prefix which we should trim
@@ -30,9 +33,17 @@ public abstract class Controller {
             byte[] idTokenBytes = Base64.getDecoder().decode(base64EncodedPayload);
             String idTokenDecoded = new String(idTokenBytes);
 
-            JsonNode parent = mapper.readTree(idTokenDecoded);
-            tenantID = parent.path(TENANT_KEY).asText();
+            JsonNode tokenTree = mapper.readTree(idTokenDecoded);
+            JsonNode tenantsTree = tokenTree.get(TENANTS_MAP_KEY);
+
+            String tenantID = tenantsTree.path(CONSUMER_TENANT_KEY).asText();
+            String providerTenantID = tenantsTree.path(PROVIDER_TENANT_KEY).asText();
+            if (providerTenantID.isEmpty()) {
+                providerTenantID = tenantID;
+            }
+            tenantsPair = Pair.of(tenantID, providerTenantID);
         }
-        return tenantID;
+
+        return tenantsPair;
     }
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -12,9 +12,9 @@ public abstract class Controller {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private final String TENANTS_MAP_KEY = "tenants";
-    private final String CONSUMER_TENANT_KEY = "tenant";
-    private final String PROVIDER_TENANT_KEY = "provider_tenant";
+    private final String TENANTS_MAP_KEY = "tenant";
+    private final String CONSUMER_TENANT_KEY = "consumerTenant";
+    private final String PROVIDER_TENANT_KEY = "providerTenant";
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String JWT_TOKEN_SPLIT_PARTS = "\\.";
     private final int PAYLOAD_INDEX = 1;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -34,7 +34,9 @@ public abstract class Controller {
             String idTokenDecoded = new String(idTokenBytes);
 
             JsonNode tokenTree = mapper.readTree(idTokenDecoded);
-            JsonNode tenantsTree = mapper.readTree(tokenTree.get(TENANTS_MAP_KEY).asText().replace("\\",""));
+            String unescapedTenants = tokenTree.get(TENANTS_MAP_KEY).asText().replace("\\", "");
+
+            JsonNode tenantsTree = mapper.readTree(unescapedTenants);
 
             String tenantID = tenantsTree.path(CONSUMER_TENANT_KEY).asText();
             String providerTenantID = tenantsTree.path(PROVIDER_TENANT_KEY).asText();

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/Controller.java
@@ -13,8 +13,8 @@ public abstract class Controller {
     private static final ObjectMapper mapper = new ObjectMapper();
 
     private final String TENANTS_MAP_KEY = "tenant";
-    private final String CONSUMER_TENANT_KEY = "consumerTenant";
-    private final String PROVIDER_TENANT_KEY = "providerTenant";
+    private final String CONSUMER_TENANT_KEY = "externalTenant";
+    private final String PROVIDER_TENANT_KEY = "providerExternalTenant";
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String JWT_TOKEN_SPLIT_PARTS = "\\.";
     private final int PAYLOAD_INDEX = 1;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -9,6 +9,7 @@ import org.apache.olingo.server.api.debug.DefaultDebugSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -38,17 +39,24 @@ public class ODataController extends com.sap.cloud.cmp.ord.service.controller.Co
 
     private JPAODataClaimsProvider createClaims(final HttpServletRequest request) throws IOException {
         final JPAODataClaimsProvider claims = new JPAODataClaimsProvider();
-
-        String tenantID = super.extractInternalTenantIdFromIDToken(request);
+        Pair<String, String> tenantIDs = super.extractTenantsFromIDToken(request);
+        if (tenantIDs == null) {
+            logger.warn("Could not determine tenants claim");
+            return claims;
+        }
+        String tenantID = tenantIDs.getFirst();
+        String providerTenantID = tenantIDs.getSecond();
         if (tenantID != null && !tenantID.isEmpty()) {
             try {
-                final JPAClaimsPair<UUID> user = new JPAClaimsPair<>(UUID.fromString(tenantID));
-                claims.add("tenant_id", user);
+                final JPAClaimsPair<UUID> tenantJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
+                final JPAClaimsPair<UUID> providerTenantJPAPair = new JPAClaimsPair<>(UUID.fromString(providerTenantID));
+                claims.add("tenant_id", tenantJPAPair);
+                claims.add("provider_tenant_id", providerTenantJPAPair);
             } catch (IllegalArgumentException e) {
                 logger.warn("Could not parse tenant uuid");
             }
         } else {
-            logger.warn("Could not determine tenant claim");
+            logger.warn("Could not determine tenant from tenants claim");
         }
         return claims;
     }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -46,7 +46,11 @@ public class ODataController extends com.sap.cloud.cmp.ord.service.controller.Co
         }
         String tenantID = tenantIDs.getFirst();
         String providerTenantID = tenantIDs.getSecond();
-        if (tenantID != null && !tenantID.isEmpty()) {
+        if (tenantID == null || tenantID.isEmpty()) {
+            logger.warn("Could not determine tenant from tenants claim");
+        } else if (providerTenantID == null || providerTenantID.isEmpty()) {
+            logger.warn("Could not determine provider tenant from tenants claim");
+        } else {
             try {
                 final JPAClaimsPair<UUID> tenantJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
                 final JPAClaimsPair<UUID> providerTenantJPAPair = new JPAClaimsPair<>(UUID.fromString(providerTenantID));
@@ -55,8 +59,6 @@ public class ODataController extends com.sap.cloud.cmp.ord.service.controller.Co
             } catch (IllegalArgumentException e) {
                 logger.warn("Could not parse tenant uuid");
             }
-        } else {
-            logger.warn("Could not determine tenant from tenants claim");
         }
         return claims;
     }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/SpecificationsController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/SpecificationsController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,14 +52,21 @@ public class SpecificationsController extends com.sap.cloud.cmp.ord.service.cont
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE, examples = @ExampleObject(name = "example", value = "Not Found"), schema = @Schema(implementation = String.class)))
     })
     public void getApiSpec(HttpServletRequest request, HttpServletResponse response, @PathVariable final String apiId, @PathVariable final String specId) throws IOException {
-        String tenantID = super.extractInternalTenantIdFromIDToken(request);
-        if (tenantID == null || tenantID.isEmpty()) {
+        Pair<String, String> tenantIDs = super.extractTenantsFromIDToken(request);
+        if (tenantIDs == null) {
+            respond(response, HttpServletResponse.SC_BAD_REQUEST, MediaType.TEXT_PLAIN_VALUE, INVALID_TENANT_ID_ERROR_MESSAGE);
+            return;
+        }
+
+        String tenantID = tenantIDs.getFirst();
+        String providerTenantID = tenantIDs.getSecond();
+        if (tenantID == null || providerTenantID == null || tenantID.isEmpty() || providerTenantID.isEmpty()) {
             respond(response, HttpServletResponse.SC_BAD_REQUEST, MediaType.TEXT_PLAIN_VALUE, INVALID_TENANT_ID_ERROR_MESSAGE);
             return;
         }
 
         try {
-            SpecificationEntity apiSpec = specRepository.getBySpecIdAndApiDefinitionIdAndTenant(UUID.fromString(specId), UUID.fromString(apiId), UUID.fromString(tenantID));
+            SpecificationEntity apiSpec = specRepository.getBySpecIdAndApiDefinitionIdAndTenantAndProviderTenant(UUID.fromString(specId), UUID.fromString(apiId), UUID.fromString(tenantID), UUID.fromString(providerTenantID));
             if (apiSpec == null) {
                 respond(response, HttpServletResponse.SC_NOT_FOUND, MediaType.TEXT_PLAIN_VALUE, NOT_FOUND_MESSAGE);
                 return;
@@ -80,14 +88,21 @@ public class SpecificationsController extends com.sap.cloud.cmp.ord.service.cont
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE, examples = @ExampleObject(name = "example", value = "Not Found"), schema = @Schema(implementation = String.class)))
     })
     public void getEventSpec(HttpServletRequest request, HttpServletResponse response, @PathVariable final String eventId, @PathVariable final String specId) throws IOException {
-        String tenantID = super.extractInternalTenantIdFromIDToken(request);
-        if (tenantID == null || tenantID.isEmpty()) {
+        Pair<String, String> tenantIDs = super.extractTenantsFromIDToken(request);
+        if (tenantIDs == null) {
+            respond(response, HttpServletResponse.SC_BAD_REQUEST, MediaType.TEXT_PLAIN_VALUE, INVALID_TENANT_ID_ERROR_MESSAGE);
+            return;
+        }
+
+        String tenantID = tenantIDs.getFirst();
+        String providerTenantID = tenantIDs.getSecond();
+        if (tenantID == null || providerTenantID == null || tenantID.isEmpty() || providerTenantID.isEmpty()) {
             respond(response, HttpServletResponse.SC_BAD_REQUEST, MediaType.TEXT_PLAIN_VALUE, INVALID_TENANT_ID_ERROR_MESSAGE);
             return;
         }
 
         try {
-            SpecificationEntity eventSpec = specRepository.getBySpecIdAndEventDefinitionIdAndTenant(UUID.fromString(specId), UUID.fromString(eventId), UUID.fromString(tenantID));
+            SpecificationEntity eventSpec = specRepository.getBySpecIdAndEventDefinitionIdAndTenantAndProviderTenant(UUID.fromString(specId), UUID.fromString(eventId), UUID.fromString(tenantID), UUID.fromString(providerTenantID));
             if (eventSpec == null) {
                 respond(response, HttpServletResponse.SC_NOT_FOUND, MediaType.TEXT_PLAIN_VALUE, NOT_FOUND_MESSAGE);
                 return;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SpecRepository.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SpecRepository.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 @Repository
 public interface SpecRepository extends JpaRepository<SpecificationEntity, UUID> {
-    SpecificationEntity getBySpecIdAndApiDefinitionIdAndTenant(UUID id, UUID apiDefId, UUID tenant);
+    SpecificationEntity getBySpecIdAndApiDefinitionIdAndTenantAndProviderTenant(UUID id, UUID apiDefId, UUID tenant, UUID providerTenant);
 
-    SpecificationEntity getBySpecIdAndEventDefinitionIdAndTenant(UUID id, UUID apiDefId, UUID tenant);
+    SpecificationEntity getBySpecIdAndEventDefinitionIdAndTenantAndProviderTenant(UUID id, UUID apiDefId, UUID tenant, UUID providerTenant);
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -65,6 +65,13 @@ public class APIEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "provider_tenant_id")
+    @EdmIgnore
+    @Column(name = "provider_tenant_id", length = 256)
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID providerTenant;
+
     @ElementCollection
     @CollectionTable(name = "tags", joinColumns = @JoinColumn(name = "api_definition_id"))
     private List<ArrayElement> tags;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
@@ -41,6 +41,13 @@ public class BundleEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "provider_tenant_id")
+    @EdmIgnore
+    @Column(name = "provider_tenant_id", length = 256)
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID providerTenant;
+
     @ElementCollection
     @CollectionTable(name = "links", joinColumns = @JoinColumn(name = "bundle_id"))
     private List<Link> links;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -52,6 +52,13 @@ public class EventEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "provider_tenant_id")
+    @EdmIgnore
+    @Column(name = "provider_tenant_id", length = 256)
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID providerTenant;
+
     @ElementCollection
     @CollectionTable(name = "changelog_entries", joinColumns = @JoinColumn(name = "event_definition_id"))
     private List<ChangelogEntry> changelogEntries;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SpecificationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SpecificationEntity.java
@@ -46,6 +46,13 @@ public class SpecificationEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "provider_tenant_id")
+    @EdmIgnore
+    @Column(name = "provider_tenant_id", length = 256)
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID providerTenant;
+
     public String getSpecData() {
         return specData;
     }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
@@ -56,6 +56,13 @@ public class SystemInstanceEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "provider_tenant_id")
+    @EdmIgnore
+    @Column(name = "provider_tenant_id", length = 256)
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID providerTenant;
+
     @ElementCollection
     @CollectionTable(name = "ord_labels", joinColumns = @JoinColumn(name = "application_id"))
     private List<Label> labels;


### PR DESCRIPTION
**Description**
This PR makes changes in the ORD service which ensures that providers can access the api/event specifications of their consumers.

**Changes proposed in this pull request:**

- Extend extractInternalTenantIdFromIDToken to extract all tenants
- Extend ODataController to set all tenants as JPAClaimPairs
- Add provider_tenant property to the API models to reflect the structure of the new views introduced [here](https://github.com/kyma-incubator/compass/pull/2025). These new fields are @EdmProtectedBy the new provider_tenant coming in the ID token


