### PR TITLE
[HOTFIX] Respect dirty flag on schema version in readiness probe

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/health/ReadinessHealthIndicator.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/health/ReadinessHealthIndicator.java
@@ -32,9 +32,12 @@ public class ReadinessHealthIndicator implements HealthIndicator {
         if (!isHealthy) {
             SchemaEntity schema = schemaRepository.getByVersionNotNull();
             String currentVersion = schema.getVersion();
-            isHealthy = currentVersion.equals(version);
+            isHealthy = (currentVersion.equals(version) && !schema.isDirty());
+            if (!isHealthy) {
+                logger.error("Incompatible schema version. Expected: " + version + " Current (version, dirty): (" + currentVersion + " , " + schema.isDirty() + ")");
+                return Health.down().build();
+            }
         }
-
-        return isHealthy ? Health.up().build() : Health.down().build();
+        return Health.up().build();
     }
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SchemaEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SchemaEntity.java
@@ -17,4 +17,8 @@ public class SchemaEntity {
     public String getVersion() {
         return version;
     }
+
+    public boolean isDirty() {
+        return dirty;
+    }
 }


### PR DESCRIPTION
**Description**

Components should not be considered ready if the desired DB migration has failed.