### PR TITLE
Bump JRE image

### DIFF
--- a/components/ord-service/Dockerfile
+++ b/components/ord-service/Dockerfile
@@ -28,7 +28,7 @@ RUN ./run.sh --skip-deps --no-start --skip-tests && \
     VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout -q) && \
     mkdir /app && mv ./target/ord-service-$VERSION.jar /app/ord-service.jar
 
-FROM adoptopenjdk/openjdk11:alpine-jre
+FROM eclipse-temurin:11.0.13_8-jre-alpine
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
There are several reported vulnerabilities, and @dzahariev opened an [issue](https://giters.com/AdoptOpenJDK/openjdk-docker/issues/615) on `adoptopenjdk` side, where they said that we should switch to `eclipse-temurin` 

Changes proposed in this pull request:

- Replace `adoptopenjdk/openjdk11:alpine-jre` with corresponding and newer `eclipse-temurin:11.0.13_8-jre-alpine` image
