### PR TITLE
Bump docker image version

### DIFF
--- a/components/ord-service/Dockerfile
+++ b/components/ord-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.4-eclipse-temurin-11 AS builder
+FROM maven:3.8.6-eclipse-temurin-11 AS builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/ord-service/components/ord-service
 WORKDIR ${BASE_APP_DIR}
@@ -28,7 +28,7 @@ RUN ./run.sh --skip-deps --no-start --skip-tests && \
     VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout -q) && \
     mkdir /app && mv ./target/ord-service-$VERSION.jar /app/ord-service.jar
 
-FROM eclipse-temurin:11.0.15_10-jre-alpine
+FROM eclipse-temurin:11.0.16_8-jre-alpine
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/ord-service/Makefile
+++ b/components/ord-service/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-ord-service
 APP_PATH = components/ord-service
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-java:v20211223-c6dddc96
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-java:v20210105-9ce011db
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 export COMPONENT_DIR = $(realpath $(shell pwd))
 

--- a/components/ord-service/Makefile
+++ b/components/ord-service/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-ord-service
 APP_PATH = components/ord-service
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-java:v20210105-9ce011db
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-java:v20211223-c6dddc96
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 export COMPONENT_DIR = $(realpath $(shell pwd))
 

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.11</version>   
+        <version>2.6.11</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.sap.cloud.cmp</groupId>

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.8</version>
+        <version>2.6.11</version>   
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.sap.cloud.cmp</groupId>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- bump builder image version from `3.8.4-eclipse-temurin-11` to `3.8.6-eclipse-temurin-11`
- bump eclipse-temurin image version from `11.0.15_10-jre-alpine` to `11.0.16_8-jre-alpine`
- bump spring boot starter version from `2.6.8` to `2.6.11`

**Related issue(s)**
- kyma-incubator/compass#2575
- kyma-incubator/compass-console#70

