### PR TITLE
Adapt deploy-on-minikube for k3d

### DIFF
--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -72,10 +72,6 @@ docker-create-opts:
 MOUNT_TARGETS = build resolve pull-licenses
 $(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 
-# Builds new Docker image into Minikube's Docker Registry
-build-to-minikube: pull-licenses
-	@eval $$(minikube docker-env) && docker build -t $(IMG_NAME) .
-
 # Builds new Docker image into k3d's Docker Registry
 build-for-k3d: pull-licenses-local
 	docker build -t k3d-kyma-registry:5001/$(IMG_NAME):latest .
@@ -98,11 +94,7 @@ endif
 COPY_TARGETS = test
 $(foreach t,$(COPY_TARGETS),$(eval $(call buildpack-cp-ro,$(t))))
 
-# Sets locally built image for a given component in Minikube cluster
-deploy-on-minikube: build-to-minikube
-	kubectl set image -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) $(COMPONENT_NAME)=$(DEPLOYMENT_NAME):latest
-	kubectl rollout restart -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME)
-
+# Sets locally built image for a given component in k3d cluster
 deploy-on-k3d: build-for-k3d
 	kubectl config use-context k3d-kyma
 	kubectl patch -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) -p '{"spec":{"template":{"spec":{"containers":[{"name":"'$(COMPONENT_NAME)'","imagePullPolicy":"Always"}]}}}}'


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove `deploy-on-minikube` and `build-on-minikube` from Makefile
- add `deploy-on-k3d` and `build-for-k3d` to Makefile

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


