### PR TITLE
Bump base Docker images and dependencies

### DIFF
--- a/components/ord-service/Dockerfile
+++ b/components/ord-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.6-eclipse-temurin-11 AS builder
+FROM maven:3.8.7-eclipse-temurin-11-focal AS builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/ord-service/components/ord-service
 WORKDIR ${BASE_APP_DIR}
@@ -28,7 +28,7 @@ RUN ./run.sh --skip-deps --no-start --skip-tests && \
     VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -DforceStdout -q) && \
     mkdir /app && mv ./target/ord-service-$VERSION.jar /app/ord-service.jar
 
-FROM eclipse-temurin:11.0.16_8-jre-alpine
+FROM eclipse-temurin:11.0.18_10-jre-alpine
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -112,6 +112,46 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -75,7 +75,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.14</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+        </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.11</version>
+        <version>2.6.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.sap.cloud.cmp</groupId>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.10</version>
+            <version>4.5.14</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump builder base image from `maven:3.8.6-eclipse-temurin-11` to `maven:3.8.7-eclipse-temurin-11-focal`
- bump runtime base image from `eclipse-temurin:11.0.16_8-jre-alpine` to `eclipse-temurin:11.0.18_10-jre-alpine`
- bump `spring-boot-starter-parent` version from `2.6.11` to `2.6.14`
- bump `httpclient` version from `4.5.10` to `4.5.14`
- manually bump `snakeyaml` to `1.33` from `1.29` that comes as a dependency from `spring-boot-starter-parent`
- manually bump `io.netty` versions from `4.1.85.Final` to `4.1.87.Final`

**Related issue(s)**
- kyma-incubator/compass-console#80
- kyma-incubator/compass#2868

