### PR TITLE
Filter ORD Service response based on formations for SaaS application consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ components/ord-service/.settings/org.eclipse.core.resources.prefs
 components/ord-service/.settings/org.eclipse.jdt.apt.core.prefs
 components/ord-service/.settings/org.eclipse.jdt.core.prefs
 components/ord-service/.settings/org.eclipse.m2e.core.prefs
+
+# Java
+.java-version

--- a/components/ord-service/.gitignore
+++ b/components/ord-service/.gitignore
@@ -6,3 +6,4 @@
 .factorypath
 .settings/
 /ord-service.iml
+.java-version

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -56,7 +56,7 @@ public class ODataController {
         final JPAODataClaimsProvider claims = new JPAODataClaimsProvider();
 
         if (token == null) {
-            logger.warn("Could not determine claims because tenant is null");
+            logger.warn("Could not determine claims because token is null");
             return claims;
         }
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SelfRegisteredRuntimeRepository.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SelfRegisteredRuntimeRepository.java
@@ -9,12 +9,15 @@ import java.util.Set;
 
 
 // JPARepository is not needed in this case because there is not a specific Entity associated with the defined queries.
-// However, Spring require that in order to instantiate the repository object in it’s context.
+// However, Spring require that in order to instantiate the repository object in its context.
 // That’s why we use a random entity just to extend the interface and make the autowiring work.
 public interface SelfRegisteredRuntimeRepository extends JpaRepository<RootEntity, Integer> {
     @Query(nativeQuery = true, value = "SELECT l1.runtime_id FROM labels l1 JOIN labels l2 ON l1.runtime_id = l2.runtime_id WHERE l1.runtime_id IS NOT NULL AND l1.runtime_id IN (SELECT id FROM tenant_runtimes WHERE tenant_id = uuid(?1) AND owner = true) AND l1.key = ?2 AND l1.value = to_jsonb(?3) AND l2.key = ?4 AND l2.value = to_jsonb(?5)")
     Set<String> findSelfRegisteredRuntimesByLabels(String providerTenantId, String selfRegKey, String selfRegValue, String regionKey, String regionValue);
 
-    @Query(nativeQuery = true, value = "SELECT COUNT(*) FROM tenant_runtime_contexts trc WHERE trc.tenant_id = uuid(?1) AND trc.id IN (SELECT id FROM runtime_contexts WHERE runtime_id = uuid(?2)) AND trc.owner = true")
-    int isRuntimeSubscriptionAvailableInTenant(String consumerTenantId, String runtimeId);
+    @Query(nativeQuery = true, value = "SELECT id FROM tenant_runtime_contexts trc WHERE trc.tenant_id = uuid(?1) AND trc.id IN (SELECT id FROM runtime_contexts WHERE runtime_id = uuid(?2)) AND trc.owner = true")
+    String getRuntimeSubscriptionAvailableInTenant(String consumerTenantId, String runtimeId);
+
+    @Query(nativeQuery = true, value = "SELECT id FROM formations where name IN (SELECT elements.value AS formation_name FROM labels, jsonb_array_elements_text(labels.value) AS elements WHERE key = 'scenarios' and runtime_context_id = uuid(?1))")
+    Set<String> getFormationsThatRuntimeSubscriptionAvailableInTenantIsPartOf(String rtCtxID);
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -66,6 +66,13 @@ public class APIEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ElementCollection
     @CollectionTable(name = "tags_api_definitions", joinColumns = @JoinColumn(name = "api_definition_id"))
     private List<ArrayElement> tags;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
@@ -41,6 +41,13 @@ public class BundleEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ElementCollection
     @CollectionTable(name = "links_bundles", joinColumns = @JoinColumn(name = "bundle_id"))
     private List<Link> links;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -42,12 +42,12 @@ public class DestinationEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
-    @EdmProtectedBy(name = "formation_scope")
-    @EdmIgnore
-    @Column(name = "formation_id")
-    @Convert("uuidConverter")
-    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
-    private UUID formationID;
+//    @EdmProtectedBy(name = "formation_scope")
+//    @EdmIgnore
+//    @Column(name = "formation_id")
+//    @Convert("uuidConverter")
+//    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+//    private UUID formationID;
 
     @Column(name = "sensitive_data", length = Integer.MAX_VALUE)
     private String sensitiveData;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -42,6 +42,13 @@ public class DestinationEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @Column(name = "sensitive_data", length = Integer.MAX_VALUE)
     private String sensitiveData;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -42,13 +42,6 @@ public class DestinationEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
-//    @EdmProtectedBy(name = "formation_scope")
-//    @EdmIgnore
-//    @Column(name = "formation_id")
-//    @Convert("uuidConverter")
-//    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
-//    private UUID formationID;
-
     @Column(name = "sensitive_data", length = Integer.MAX_VALUE)
     private String sensitiveData;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -53,6 +53,13 @@ public class EventEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ElementCollection
     @CollectionTable(name = "changelog_entries_event_definitions", joinColumns = @JoinColumn(name = "event_definition_id"))
     private List<ChangelogEntry> changelogEntries;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
@@ -52,6 +52,13 @@ public class PackageEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ElementCollection
     @CollectionTable(name = "package_links", joinColumns = @JoinColumn(name = "package_id"))
     private List<PackageLink> packageLinks;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
@@ -83,4 +83,11 @@ public class ProductEntity {
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
+
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/SystemInstanceEntity.java
@@ -56,6 +56,13 @@ public class SystemInstanceEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ElementCollection
     @CollectionTable(name = "ord_labels_applications", joinColumns = @JoinColumn(name = "application_id"))
     private List<Label> labels;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
@@ -33,6 +33,13 @@ public class TombstoneEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @EdmIgnore
     @Column(name = "app_id", length = 256)
     @Convert("uuidConverter")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
@@ -62,4 +62,11 @@ public class VendorEntity {
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID tenant;
+
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

This PR adds `@EdmProtectedBy` annotations to each entity in order to allow the jpa-processor to filter based on formation. When a call to the ORD Service is made we set claims with the actual values that should be used in the `EdmProtectedBy` filtering:
- In case single tenant is present (discovery based on tenancy) - Add default formation claim `aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa` in the JPA Context.
- In case double tenant is present (consumer provider flow) -  Find all the formations that the RuntimeContext is part of and add them as formation claims in the JPA context.

**Changes proposed in this pull request**
- add `formation_id` field and annotation to the proper entities
- change repo func to return the single runtime context if present instead of the count
- add repo func to get all the formations that the runtime context is part of
- set and use the claims for filtering

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2901


