### PR TITLE
Bump dependencies

### DIFF
--- a/components/ord-service/Dockerfile
+++ b/components/ord-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.7-eclipse-temurin-11-focal AS builder
+FROM maven:3.9.1-eclipse-temurin-11-focal AS builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/ord-service/components/ord-service
 WORKDIR ${BASE_APP_DIR}

--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.14</version>
+        <version>2.7.10</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.sap.cloud.cmp</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump maven base image from `3.8.7-eclipse-temurin-11-focal` to `3.9.1-eclipse-temurin-11-focal`
- bump spring boot from `2.6.14` to `2.7.10`
- bump `snakeyaml` from `1.33` to `2.0`

**Related issue(s)**
- kyma-incubator/compass#3022
- kyma-incubator/compass-console#83

