### PR TITLE
Allow BTP Applications onboarded as Application Templates to consume ORD Service APIs

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/config/TokenParserConfig.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/config/TokenParserConfig.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRuntimeRepository;
+import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRepository;
 import com.sap.cloud.cmp.ord.service.token.SubscriptionHelper;
 import com.sap.cloud.cmp.ord.service.token.TokenParser;
 
@@ -21,7 +21,7 @@ public class TokenParserConfig {
     private String tokenPrefix;
 
     @Bean
-    public TokenParser tokenParser(SelfRegisteredRuntimeRepository repo) {
+    public TokenParser tokenParser(SelfRegisteredRepository repo) {
         return new TokenParser(new SubscriptionHelper(selfRegKey, regionKey, tokenPrefix, repo));
     }
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/SubscriptionHelper.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/SubscriptionHelper.java
@@ -1,15 +1,15 @@
 package com.sap.cloud.cmp.ord.service.token;
 
-import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRuntimeRepository;
+import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRepository;
 
 public class SubscriptionHelper {
 
     private String selfRegKey;
     private String regionKey;
     private String tokenPrefix;
-    private SelfRegisteredRuntimeRepository repo;
+    private SelfRegisteredRepository repo;
 
-    public SubscriptionHelper(String selfRegKey, String regionKey, String tokenPrefix, SelfRegisteredRuntimeRepository repo) {
+    public SubscriptionHelper(String selfRegKey, String regionKey, String tokenPrefix, SelfRegisteredRepository repo) {
         this.selfRegKey = selfRegKey;
         this.regionKey = regionKey;
         this.tokenPrefix = tokenPrefix;
@@ -28,7 +28,7 @@ public class SubscriptionHelper {
         return tokenPrefix;
     }
 
-    public SelfRegisteredRuntimeRepository getRepo() {
+    public SelfRegisteredRepository getRepo() {
         return repo;
     }
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/Token.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/Token.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRuntimeRepository;
+import com.sap.cloud.cmp.ord.service.repository.SelfRegisteredRepository;
 
 public class Token {
     private static final Logger logger = LoggerFactory.getLogger(Token.class);
@@ -79,7 +79,7 @@ public class Token {
                 return "";
             }
 
-            SelfRegisteredRuntimeRepository repo = subscriptionHelper.getRepo();
+            SelfRegisteredRepository repo = subscriptionHelper.getRepo();
             Set<String> runtimeIds = repo.findSelfRegisteredRuntimesByLabels(providerTenantID, subscriptionHelper.getSelfRegKey(),
                 tokenClientId, subscriptionHelper.getRegionKey(), tokenRegion);
             for (String runtimeId : runtimeIds) {
@@ -90,6 +90,18 @@ public class Token {
                     return tenant;
                 }
             }
+
+            Set<String> appTemplateIds = repo.findSelfRegisteredApplicationTemplatesByLabels(providerTenantID, subscriptionHelper.getSelfRegKey(),
+                    tokenClientId, subscriptionHelper.getRegionKey(), tokenRegion);
+            for (String appTemplateId : appTemplateIds) {
+                String applicationSubscriptionAvailableInTenant = repo.getApplicationSubscriptionAvailableInTenant(tenant, appTemplateId);
+                if (applicationSubscriptionAvailableInTenant != null && !applicationSubscriptionAvailableInTenant.isEmpty()) {
+                    Set<String> formationIDs = repo.getFormationsThatApplicationSubscriptionAvailableInTenantIsPartOf(applicationSubscriptionAvailableInTenant);
+                    this.formationIDsClaims.addAll(formationIDs);
+                    return tenant;
+                }
+            }
+
         } catch (IOException ignored) {}
 
         this.formationIDsClaims.add(DEFAULT_FORMATION_ID_CLAIM);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Allow BTP Applications onboarded as Application Templates to consume ORD Service APIs


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


