### PR TITLE
Fix missing top-level filter in the generated SQL where clause

### DIFF
--- a/components/ord-service/pom.xml
+++ b/components/ord-service/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.source>1.8</project.build.source>
         <java.version>17</java.version>
-        <jpa-processor>0.3.11.2-SNAPSHOT</jpa-processor>
+        <jpa-processor>0.3.11.3-SNAPSHOT</jpa-processor>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Description**

Reverting the fix described in the following PR: https://github.com/SAP/olingo-jpa-processor-v4/pull/158 as the concern that Oliver brought there seems to have a bigger impact than expected. As stated in the comments that's a trade-off that we accepted at that time. However, when we did new performance evaluations it seems like the performance is better without the "fix". Back in the day we had many missing indices as well as casts and view problems that made us think otherwise.


