### PR TITLE
Adapt tenant claims

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -37,6 +37,7 @@ public class ODataController {
     private final String INTERNAL_VISIBILITY = "internal";
     private final String PRIVATE_VISIBILITY = "private";
     private final String EMPTY_FORMATIONS_DEFAULT_FORMATION_ID_CLAIM = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    private final String DEFAULT_TENANT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 
     @RequestMapping(value = "**", method = {RequestMethod.GET})
     public void handleODataRequest(HttpServletRequest request, HttpServletResponse response) throws ODataException, IOException {
@@ -66,16 +67,23 @@ public class ODataController {
             return claims;
         }
 
-        final JPAClaimsPair<UUID> tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
-        claims.add("tenant_id", tenantIDJPAPair);
-
+        boolean shouldUseDefaultTenant = false;
         if (token.getFormationIDsClaims().isEmpty()) {
             logger.warn("Could not determine formation claim");
             claims.add("formation_scope", new JPAClaimsPair<>(UUID.fromString(EMPTY_FORMATIONS_DEFAULT_FORMATION_ID_CLAIM))); // in the consumer-provider flow, if there are currently no formations the rtCtx is part of; we will return empty array this way instead of misleading claims error
         } else {
+            shouldUseDefaultTenant = true; // when we know that the filtering will be based on formation_id/s, we want to set a default tenant_id
             for (String formationID : token.getFormationIDsClaims()) {
                 claims.add("formation_scope", new JPAClaimsPair<>(UUID.fromString(formationID)));
             }
+        }
+
+        if (shouldUseDefaultTenant) {
+            final JPAClaimsPair<UUID> tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(DEFAULT_TENANT_ID));
+            claims.add("tenant_id", tenantIDJPAPair);
+        } else {
+            final JPAClaimsPair<UUID> tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
+            claims.add("tenant_id", tenantIDJPAPair);
         }
 
         final JPAClaimsPair<String> publicVisibilityScopeJPAPair = new JPAClaimsPair<>(PUBLIC_VISIBILITY);

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -67,13 +67,15 @@ public class ODataController {
             return claims;
         }
 
-        boolean shouldUseDefaultTenant = false;
+        boolean shouldUseDefaultTenant = true;
         if (token.getFormationIDsClaims().isEmpty()) {
             logger.warn("Could not determine formation claim");
             claims.add("formation_scope", new JPAClaimsPair<>(UUID.fromString(EMPTY_FORMATIONS_DEFAULT_FORMATION_ID_CLAIM))); // in the consumer-provider flow, if there are currently no formations the rtCtx is part of; we will return empty array this way instead of misleading claims error
         } else {
-            shouldUseDefaultTenant = true; // when we know that the filtering will be based on formation_id/s, we want to set a default tenant_id
             for (String formationID : token.getFormationIDsClaims()) {
+                if (formationID.equals(Token.DEFAULT_FORMATION_ID_CLAIM)) {
+                    shouldUseDefaultTenant = false; // if the DEFAULT_FORMATION_ID_CLAIM is present it means that we will be filtering by tenant_id, so we don't want to use the default tenant_id
+                }
                 claims.add("formation_scope", new JPAClaimsPair<>(UUID.fromString(formationID)));
             }
         }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/controller/ODataController.java
@@ -67,6 +67,9 @@ public class ODataController {
             return claims;
         }
 
+        final JPAClaimsPair<UUID> destinationTenantJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
+        claims.add("destination_tenant_id", destinationTenantJPAPair);
+
         boolean shouldUseDefaultTenant = true;
         if (token.getFormationIDsClaims().isEmpty()) {
             logger.warn("Could not determine formation claim");
@@ -80,13 +83,13 @@ public class ODataController {
             }
         }
 
+        final JPAClaimsPair<UUID> tenantIDJPAPair;
         if (shouldUseDefaultTenant) {
-            final JPAClaimsPair<UUID> tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(DEFAULT_TENANT_ID));
-            claims.add("tenant_id", tenantIDJPAPair);
+            tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(DEFAULT_TENANT_ID));
         } else {
-            final JPAClaimsPair<UUID> tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
-            claims.add("tenant_id", tenantIDJPAPair);
+            tenantIDJPAPair = new JPAClaimsPair<>(UUID.fromString(tenantID));
         }
+        claims.add("tenant_id", tenantIDJPAPair);
 
         final JPAClaimsPair<String> publicVisibilityScopeJPAPair = new JPAClaimsPair<>(PUBLIC_VISIBILITY);
         claims.add("visibility_scope", publicVisibilityScopeJPAPair);

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -35,7 +35,7 @@ public class DestinationEntity {
     @Column(name = "url", length = Integer.MAX_VALUE)
     private String url;
 
-    @EdmProtectedBy(name = "tenant_id")
+    @EdmProtectedBy(name = "destination_tenant_id")
     @EdmIgnore
     @Column(name = "tenant_id", length = 256)
     @Convert("uuidConverter")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/Token.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/Token.java
@@ -31,7 +31,7 @@ public class Token {
     private final String INTERNAL_VISIBILITY_SCOPE = "internal_visibility:read";
 
     // In case single tenant is present (discovery based on tenancy) in the call, we use this default formation claim
-    public final String DEFAULT_FORMATION_ID_CLAIM = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    public final static String DEFAULT_FORMATION_ID_CLAIM = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
     private static final ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

This PR adopts the changes introduced in https://github.com/kyma-incubator/compass/pull/3470. Basically, a filtering by tenant_id or formation_id is enabled instead of filtering by tenant_id or formation_id + tenant_id.

When we are in the consumer-provider flow (meaning that there are formation claims) we will be filtering by formation_id and we set for tenant claim the default tenant value.

When for formation claims there is only the default formation value, that means that we will be filtering only by tenant_id, so then we set the tenant_id in the tenant claims.

However, a new `destination_tenant_id` claims is introduced for the `DestinationEntity` which is always populated with the tenant_id. This is because we want the Destinations to be visible only for the tenant it lives in or for the caller which calls on behalf of it. In this case the default tenant value approach won't be valid.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3470


