### PR TITLE
Extend system discovery mechanisms

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SelfRegisteredRepository.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/repository/SelfRegisteredRepository.java
@@ -29,4 +29,7 @@ public interface SelfRegisteredRepository extends JpaRepository<RootEntity, Inte
 
     @Query(nativeQuery = true, value = "SELECT f.id FROM formations f WHERE jsonb_exists((SELECT l.value FROM labels l WHERE l.key = 'scenarios' and l.app_id = uuid(?1)), f.name) AND f.formation_template_id IN (SELECT ft.id FROM formation_templates ft WHERE jsonb_exists(ft.discovery_consumers, (SELECT l.value->>0 FROM labels l WHERE l.key = 'applicationType' AND l.app_id = uuid(?1))))")
     Set<String> getFormationsThatApplicationSubscriptionAvailableInTenantIsPartOf(String appId);
+
+    @Query(nativeQuery = true, value = "SELECT id FROM applications WHERE local_tenant_id = uuid(?1) and app_template_id = uuid(?2)")
+    String findApplicationByLocalTenantIdAndApplicationTemplateId(String appLocalTenantId, String appTemplateId);
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/TokenParser.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/token/TokenParser.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 public class TokenParser {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String APPLICATION_TENANT_ID_HEADER_KEY = "applicationTenantId";
 
     private SubscriptionHelper subscriptionHelper;
 
@@ -21,6 +22,8 @@ public class TokenParser {
             return null;
         }
 
-        return new Token(subscriptionHelper, idToken);
+        final String applicationTenantId = request.getHeader(APPLICATION_TENANT_ID_HEADER_KEY);
+
+        return new Token(subscriptionHelper, idToken, applicationTenantId);
     }
 }

--- a/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/destinations/FetchingDestinationsTest.java
+++ b/components/ord-service/src/test/java/com/sap/cloud/cmp/ord/service/destinations/FetchingDestinationsTest.java
@@ -147,7 +147,7 @@ public class FetchingDestinationsTest {
 
     @Test
     public void testReloadFilter_ReturnsInternalServerError_WhenCallToDestinationFetcherFails() throws Exception {
-        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE));
+        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE, null));
         doThrow(new RestClientResponseException("Request failed",
             HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(),
             null, null, null)
@@ -166,7 +166,7 @@ public class FetchingDestinationsTest {
     @Test
     public void testReloadFilter_ReturnsODataResponse_WhenCallToDestinationFetcherSucceeds() throws Exception {
         String odataResponse = "{}";
-        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE));
+        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE, null));
 
         TestLogic testLogic = () -> {
             mvc.perform(
@@ -232,7 +232,7 @@ public class FetchingDestinationsTest {
 
     @Test
     public void testSensitiveDataFilter_ReturnsInternalServerError_WhenCallToDestinationFetcherFails() throws Exception {
-        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE));
+        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE, null));
 
         String odataResponse =
         "{" +
@@ -263,7 +263,7 @@ public class FetchingDestinationsTest {
 
      @Test
      public void testSensitiveDataFilter_ReturnsDestinationsWithSensitiveDataWhereAvailableInXML() throws Exception {
-         when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE));
+         when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE, null));
 
          String odataResponse =
          "<feed>" +
@@ -312,7 +312,7 @@ public class FetchingDestinationsTest {
 
     @Test
     public void testSensitiveDataFilter_ReturnsDestinationsWithSensitiveDataWhereAvailableInJSON() throws Exception {
-        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE));
+        when(tokenParser.fromRequest(any(HttpServletRequest.class))).thenReturn(new Token(null, TOKEN_VALUE, null));
 
         String odataResponse =
         "{" +


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Extend the system discovery, allowing providers to consume ORD content on behalf of their tenant by checking the `applicationTenantId` request header.

Changes proposed in this pull request:
- 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


