### PR TITLE
Remove duplicates when joining by formation_id as well

### DIFF
--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/APIEntity.java
@@ -158,25 +158,45 @@ public class APIEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "package_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-            name = "bundle_references",
-            joinColumns = @JoinColumn(name = "api_def_id"),
-            inverseJoinColumns = @JoinColumn(name = "bundle_id"))
+            name = "tenants_api_bundle_reference",
+            joinColumns = {
+                    @JoinColumn(name = "api_definition_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "bundle_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<BundleEntity> consumptionBundles;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "api_product",
-            joinColumns = {@JoinColumn(name = "api_definition_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id")})
+            joinColumns = {
+                    @JoinColumn(name = "api_definition_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "product_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<ProductEntity> products;
 
     @Column(name = "implementation_standard")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectAPIResource.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectAPIResource.java
@@ -2,13 +2,12 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
+import jakarta.persistence.*;
+import org.eclipse.persistence.annotations.Convert;
+import org.eclipse.persistence.annotations.TypeConverter;
+
+import java.util.UUID;
 
 @Entity(name = "aspectApiResource")
 @Table(name = "aspect_api_resources")
@@ -24,7 +23,17 @@ public class AspectAPIResource {
     @EdmIgnore
     private String aspectId;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "aspect_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "aspect_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private AspectEntity aspect;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectAPIResource.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectAPIResource.java
@@ -3,7 +3,14 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
@@ -25,7 +32,7 @@ public class AspectAPIResource {
 
     @EdmProtectedBy(name = "formation_scope")
     @EdmIgnore
-    @Column(name = "formation_id")
+    @Column(name = "formation_id", length = 256)
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID formationID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEntity.java
@@ -4,20 +4,13 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name="aspect")
@@ -56,7 +49,10 @@ public class AspectEntity {
     private UUID integrationDependencyId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "integration_dependency_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "integration_dependency_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private IntegrationDependencyEntity integrationDependency;
 
     @Column(name = "title")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEntity.java
@@ -4,7 +4,15 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEventResource.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEventResource.java
@@ -1,11 +1,20 @@
 package com.sap.cloud.cmp.ord.service.storage.model;
 
-import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
 import java.util.List;
 import java.util.UUID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEventResource.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/AspectEventResource.java
@@ -1,20 +1,11 @@
 package com.sap.cloud.cmp.ord.service.storage.model;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
-
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import java.util.List;
 import java.util.UUID;
@@ -54,7 +45,10 @@ public class AspectEventResource {
     private String aspectId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "aspect_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "aspect_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private AspectEntity aspect;
 
     @ElementCollection

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
@@ -4,21 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "consumptionBundle")
@@ -98,7 +90,10 @@ public class BundleEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @ManyToMany(mappedBy = "consumptionBundles", fetch = FetchType.LAZY)

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/BundleEntity.java
@@ -4,7 +4,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ManyToMany;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/CapabilityEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/CapabilityEntity.java
@@ -3,7 +3,16 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/CapabilityEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/CapabilityEntity.java
@@ -3,21 +3,13 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "capability")
@@ -101,7 +93,10 @@ public class CapabilityEntity {
     private List<CapabilityDefinition> definitions;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "package_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @EdmIgnore
@@ -111,7 +106,10 @@ public class CapabilityEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @EdmProtectedBy(name = "tenant_id")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DataProductEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DataProductEntity.java
@@ -27,7 +27,10 @@ public class DataProductEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @EdmProtectedBy(name = "tenant_id")
@@ -71,7 +74,10 @@ public class DataProductEntity {
     private UUID partOfPackage;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "package_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @Column(name = "last_update")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -46,10 +46,23 @@ public class DestinationEntity {
     @Column(name = "sensitive_data", length = Integer.MAX_VALUE)
     private String sensitiveData;
 
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-            name = "destinations",
-            joinColumns = @JoinColumn(name = "id"),
-            inverseJoinColumns = @JoinColumn(name = "bundle_id"))
+            name = "tenants_destinations",
+            joinColumns = {
+                    @JoinColumn(name = "id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "bundle_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<BundleEntity> consumptionBundles;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/DestinationEntity.java
@@ -47,7 +47,7 @@ public class DestinationEntity {
     private String sensitiveData;
 
     @EdmIgnore
-    @Column(name = "formation_id")
+    @Column(name = "formation_id", length = 256)
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID formationID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeEntity.java
@@ -4,24 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "entityType")
@@ -79,8 +68,11 @@ public class EntityTypeEntity {
     @NotNull
     private UUID partOfPackage;
 
-    @ManyToOne(fetch = FetchType.LAZY) 
-    @JoinColumn(name = "package_id", insertable = false, updatable = false) 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @EdmProtectedBy(name = "visibility_scope")
@@ -94,8 +86,15 @@ public class EntityTypeEntity {
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "entity_type_product",
-            joinColumns = {@JoinColumn(name = "entity_type_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id")})
+            joinColumns = {
+                    @JoinColumn(name = "entity_type_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "product_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<ProductEntity> products;
 
     @Column(name = "policy_level", length = 256)
@@ -151,6 +150,9 @@ public class EntityTypeEntity {
     private UUID formationID;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeEntity.java
@@ -4,7 +4,19 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Embedded;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeMappingEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeMappingEntity.java
@@ -3,21 +3,12 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
-
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 @Entity(name = "entityTypeMapping")
 @Table(name = "tenants_entity_type_mappings")
@@ -55,11 +46,24 @@ public class EntityTypeMappingEntity {
     @CollectionTable(name = "entity_type_targets_entity_type_mappings", joinColumns = @JoinColumn(name = "entity_type_mapping_id", referencedColumnName = "id"))
     private List<EntityTypeTarget> entityTypeTargets;
 
+    @EdmProtectedBy(name = "formation_scope")
+    @EdmIgnore
+    @Column(name = "formation_id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID formationID;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "api_definition_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "api_definition_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private APIEntity apiResource;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_definition_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "event_definition_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private EventEntity eventResource;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeMappingEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EntityTypeMappingEntity.java
@@ -3,7 +3,16 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
@@ -48,7 +57,7 @@ public class EntityTypeMappingEntity {
 
     @EdmProtectedBy(name = "formation_scope")
     @EdmIgnore
-    @Column(name = "formation_id")
+    @Column(name = "formation_id", length = 256)
     @Convert("uuidConverter")
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID formationID;

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -4,7 +4,20 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Embedded;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/EventEntity.java
@@ -4,25 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "event")
@@ -94,7 +82,10 @@ public class EventEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @OneToMany(mappedBy = "eventResource", fetch = FetchType.LAZY)
@@ -180,21 +171,38 @@ public class EventEntity {
     private String deprecationDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "package_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-            name = "bundle_references",
-            joinColumns = @JoinColumn(name = "event_def_id"),
-            inverseJoinColumns = @JoinColumn(name = "bundle_id"))
+            name = "tenants_event_bundle_reference",
+            joinColumns = {
+                    @JoinColumn(name = "event_def_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "bundle_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<BundleEntity> consumptionBundles;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "event_product",
-            joinColumns = {@JoinColumn(name = "event_definition_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id")})
+            joinColumns = {
+                    @JoinColumn(name = "event_definition_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "product_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<ProductEntity> products;
 
     @Column(name = "responsible")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/IntegrationDependencyEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/IntegrationDependencyEntity.java
@@ -4,7 +4,17 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.OneToMany;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/IntegrationDependencyEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/IntegrationDependencyEntity.java
@@ -4,22 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "integrationDependency")
@@ -37,8 +28,11 @@ public class IntegrationDependencyEntity {
     @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
     private UUID appId;
 
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
     private SystemInstanceEntity systemInstance;
 
     @EdmProtectedBy(name = "tenant_id")
@@ -81,7 +75,10 @@ public class IntegrationDependencyEntity {
     private UUID partOfPackage;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "package_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "package_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private PackageEntity pkg;
 
     @Column(name = "last_update")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
@@ -4,7 +4,19 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/PackageEntity.java
@@ -4,24 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "package")
@@ -91,7 +80,10 @@ public class PackageEntity {
     private String vendorReference;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "vendor", referencedColumnName= "ord_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "vendor", referencedColumnName = "ord_id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private VendorEntity vendor;
 
     @EdmIgnore
@@ -101,7 +93,10 @@ public class PackageEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @ElementCollection
@@ -134,8 +129,15 @@ public class PackageEntity {
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
             name = "package_product",
-            joinColumns = {@JoinColumn(name = "package_id")},
-            inverseJoinColumns = {@JoinColumn(name = "product_id")})
+            joinColumns = {
+                    @JoinColumn(name = "package_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            },
+            inverseJoinColumns = {
+                    @JoinColumn(name = "product_id", referencedColumnName = "id"),
+                    @JoinColumn(name = "formation_id", referencedColumnName = "formation_id"),
+            }
+    )
     private Set<ProductEntity> products;
 
     @OneToMany(mappedBy = "pkg", fetch = FetchType.LAZY)

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/ProductEntity.java
@@ -55,6 +55,7 @@ public class ProductEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns({
             @JoinColumn(name = "vendor", referencedColumnName= "ord_id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
     })
     private VendorEntity vendor;
 
@@ -65,7 +66,10 @@ public class ProductEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @Column(name = "parent", length = 256)

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
@@ -2,7 +2,14 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/TombstoneEntity.java
@@ -2,19 +2,13 @@ package com.sap.cloud.cmp.ord.service.storage.model;
 
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "tombstone")
@@ -58,6 +52,9 @@ public class TombstoneEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
@@ -4,7 +4,17 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.CollectionTable;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/VendorEntity.java
@@ -4,22 +4,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.eclipse.persistence.annotations.Convert;
 import org.eclipse.persistence.annotations.TypeConverter;
 
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
 import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmProtectedBy;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 @Entity(name = "vendor")
@@ -68,7 +59,10 @@ public class VendorEntity {
     private UUID appId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "app_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "app_id", referencedColumnName = "id", insertable = false, updatable = false),
+            @JoinColumn(name = "formation_id", referencedColumnName = "formation_id", insertable = false, updatable = false),
+    })
     private SystemInstanceEntity systemInstance;
 
     @EdmProtectedBy(name = "tenant_id")

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIBundleReference.java
@@ -23,6 +23,6 @@ public class APIBundleReference implements Serializable {
     @Column(name = "tenant_id", length = 256)
     private String tenantID;
 
-    @Column(name = "formation_id")
+    @Column(name = "formation_id", length = 256)
     private boolean formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIBundleReference.java
@@ -1,0 +1,28 @@
+package com.sap.cloud.cmp.ord.service.storage.model.helperentities;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.io.Serializable;
+
+@EdmIgnore
+@Table(name = "tenants_api_bundle_reference")
+@Entity(name = "apiBundleReference")
+public class APIBundleReference implements Serializable {
+    @Id
+    @Column(name = "api_definition_id", length = 256)
+    private String apiDefID;
+
+    @Column(name = "bundle_id", length = 256)
+    private String bundleID;
+
+    @Column(name = "tenant_id", length = 256)
+    private String tenantID;
+
+    @Column(name = "formation_id")
+    private boolean formationID;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/APIProduct.java
@@ -23,4 +23,8 @@ public class APIProduct implements Serializable {
     @Id
     @Column(name = "product_id", length = 256)
     private String productID;
+
+    @Id
+    @Column(name = "formation_id", length = 256)
+    private String formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/BundleDestinations.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/BundleDestinations.java
@@ -1,0 +1,49 @@
+package com.sap.cloud.cmp.ord.service.storage.model.helperentities;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import org.eclipse.persistence.annotations.Convert;
+import org.eclipse.persistence.annotations.TypeConverter;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@EdmIgnore
+@Table(name = "tenants_destinations")
+@Entity(name = "bundleDestinations")
+public class BundleDestinations implements Serializable {
+    @Id
+    @Column(name = "id")
+    @Convert("uuidConverter")
+    @TypeConverter(name = "uuidConverter", dataType = Object.class, objectType = UUID.class)
+    private UUID Id;
+
+    @Column(name = "tenant_id", length = 256)
+    private String tenantID;
+
+    @Column(name = "formation_id", length = 256)
+    private String formationID;
+
+    @Column(name = "name", length = 256)
+    private String name;
+
+    @Column(name = "type", length = 256)
+    private String type;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "authentication")
+    private String authentication;
+
+    @Column(name = "bundle_id")
+    private String bundleID;
+
+    @Column(name = "sensitive_data")
+    private String sensitiveData;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EntityTypeProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EntityTypeProduct.java
@@ -23,4 +23,8 @@ public class EntityTypeProduct implements Serializable {
     @Id
     @Column(name = "product_id", length = 256)
     private String productID;
+
+    @Id
+    @Column(name = "formation_id", length = 256)
+    private String formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventBundleReference.java
@@ -23,6 +23,6 @@ public class EventBundleReference implements Serializable {
     @Column(name = "tenant_id", length = 256)
     private String tenantID;
 
-    @Column(name = "formation_id")
+    @Column(name = "formation_id", length = 256)
     private boolean formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventBundleReference.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventBundleReference.java
@@ -1,0 +1,28 @@
+package com.sap.cloud.cmp.ord.service.storage.model.helperentities;
+
+import com.sap.olingo.jpa.metadata.core.edm.annotation.EdmIgnore;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.io.Serializable;
+
+@EdmIgnore
+@Table(name = "tenants_event_bundle_reference")
+@Entity(name = "eventBundleReference")
+public class EventBundleReference implements Serializable {
+    @Id
+    @Column(name = "event_def_id", length = 256)
+    private String eventDefID;
+
+    @Column(name = "bundle_id", length = 256)
+    private String bundleID;
+
+    @Column(name = "tenant_id", length = 256)
+    private String tenantID;
+
+    @Column(name = "formation_id")
+    private boolean formationID;
+}

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/EventProduct.java
@@ -23,4 +23,8 @@ public class EventProduct implements Serializable {
     @Id
     @Column(name = "product_id", length = 256)
     private String productID;
+
+    @Id
+    @Column(name = "formation_id", length = 256)
+    private String formationID;
 }

--- a/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/PackageProduct.java
+++ b/components/ord-service/src/main/java/com/sap/cloud/cmp/ord/service/storage/model/helperentities/PackageProduct.java
@@ -23,4 +23,8 @@ public class PackageProduct implements Serializable {
     @Id
     @Column(name = "product_id", length = 256)
     private String productID;
+
+    @Id
+    @Column(name = "formation_id", length = 256)
+    private String formationID;
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The PR is related to [this issue](https://github.com/SAP/olingo-jpa-processor-v4/issues/276). The `distinct` clause is rightly missing meaning that the assumption about it was invalid. So, another solution had to be found.

The setup in the issue is achieved by adding the Application in two formations of the same type and calling the ORD Service in the "consumer-provider flow".

The solution in this PR is that we add the `formation_id` as join column (on top of the existing ones) across all relations between the entities. This eliminates the duplicates when the given entity is in multiple formations.

Changes proposed in this pull request:

- add `formation_id` as join column across all entity relations
- for the bundles <-> apis/events relation don't use the `bundle_reference` table but newly created views in which formation_id is available
- for the `@ManyToMany` relations, join by `formation_id` from both sides of the relation
- add some helper entities needed for enabling filtering in the odata queries

**Related issue(s)**
- compass PR: https://github.com/kyma-incubator/compass/pull/3763


